### PR TITLE
Add HTML mockups for core pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,14 @@ cd frontend
 npm install # nécessite l'accès au registre npm
 npm run dev
 ```
+
+## Prototypes HTML
+
+Le dossier `prototypes/` contient des maquettes statiques en HTML :
+
+- `index.html` : page d'accueil
+- `film.html` : page de fiche film
+- `actor.html` : page de fiche acteur
+- `news.html` : page d'article
+
+Ces pages sont interconnectées et partagent une feuille de style commune `styles.css`.

--- a/prototypes/actor.html
+++ b/prototypes/actor.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Codex - Fiche Acteur</title>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>Codex</h1>
+            <nav>
+                <a href="index.html">Accueil</a>
+                <a href="film.html">Films</a>
+                <a href="actor.html">Acteurs</a>
+                <a href="news.html">News</a>
+            </nav>
+        </div>
+    </header>
+    <main>
+        <section>
+            <h2>Nom de l'acteur</h2>
+            <img src="https://via.placeholder.com/600x350" alt="Photo de l'acteur" />
+            <p><strong>Biographie :</strong> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec interdum, nisl eget vehicula faucibus, neque metus luctus nisl, sed pulvinar libero velit in tortor.</p>
+        </section>
+        <section>
+            <h3>Filmographie</h3>
+            <ul>
+                <li><a href="film.html">Film 1</a></li>
+                <li><a href="film.html">Film 2</a></li>
+                <li><a href="film.html">Film 3</a></li>
+            </ul>
+        </section>
+        <section>
+            <h3>Articles liés</h3>
+            <ul>
+                <li><a href="news.html">Titre d'une news</a></li>
+                <li><a href="news.html">Autre article</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 Codex. Tous droits réservés.</p>
+    </footer>
+</body>
+</html>

--- a/prototypes/film.html
+++ b/prototypes/film.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Codex - Fiche Film</title>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>Codex</h1>
+            <nav>
+                <a href="index.html">Accueil</a>
+                <a href="film.html">Films</a>
+                <a href="actor.html">Acteurs</a>
+                <a href="news.html">News</a>
+            </nav>
+        </div>
+    </header>
+    <main>
+        <section>
+            <h2>Titre du film</h2>
+            <img src="https://via.placeholder.com/600x350" alt="Affiche du film" />
+            <p><strong>Date de sortie :</strong> 1 janvier 2024</p>
+            <p><strong>Synopsis :</strong> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam vehicula, nisl at convallis facilisis, metus urna pulvinar augue, a hendrerit neque urna a justo.</p>
+        </section>
+        <section>
+            <h3>Distribution</h3>
+            <ul>
+                <li><a href="actor.html">Acteur 1</a></li>
+                <li><a href="actor.html">Acteur 2</a></li>
+                <li><a href="actor.html">Acteur 3</a></li>
+            </ul>
+        </section>
+        <section>
+            <h3>Articles liés</h3>
+            <ul>
+                <li><a href="news.html">Titre d'une news</a></li>
+                <li><a href="news.html">Autre article</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 Codex. Tous droits réservés.</p>
+    </footer>
+</body>
+</html>

--- a/prototypes/index.html
+++ b/prototypes/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Codex - Accueil</title>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>Codex</h1>
+            <nav>
+                <a href="index.html">Accueil</a>
+                <a href="film.html">Films</a>
+                <a href="actor.html">Acteurs</a>
+                <a href="news.html">News</a>
+            </nav>
+        </div>
+    </header>
+    <main>
+        <section>
+            <h2>Films à l'affiche</h2>
+            <div class="cards">
+                <a class="card" href="film.html">
+                    <img src="https://via.placeholder.com/300x350" alt="Affiche du film" />
+                    <h3>Titre du film</h3>
+                </a>
+                <a class="card" href="film.html">
+                    <img src="https://via.placeholder.com/300x350" alt="Affiche du film" />
+                    <h3>Autre film</h3>
+                </a>
+            </div>
+        </section>
+        <section>
+            <h2>Dernières news</h2>
+            <ul>
+                <li><a href="news.html">Titre de l'article</a></li>
+                <li><a href="news.html">Une autre actualité</a></li>
+            </ul>
+        </section>
+        <section>
+            <h2>Acteurs populaires</h2>
+            <div class="cards">
+                <a class="card" href="actor.html">
+                    <img src="https://via.placeholder.com/300x350" alt="Photo de l'acteur" />
+                    <h3>Nom de l'acteur</h3>
+                </a>
+                <a class="card" href="actor.html">
+                    <img src="https://via.placeholder.com/300x350" alt="Photo de l'acteur" />
+                    <h3>Autre acteur</h3>
+                </a>
+            </div>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 Codex. Tous droits réservés.</p>
+    </footer>
+</body>
+</html>

--- a/prototypes/news.html
+++ b/prototypes/news.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Codex - Article</title>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>Codex</h1>
+            <nav>
+                <a href="index.html">Accueil</a>
+                <a href="film.html">Films</a>
+                <a href="actor.html">Acteurs</a>
+                <a href="news.html">News</a>
+            </nav>
+        </div>
+    </header>
+    <main>
+        <article>
+            <h2>Titre de l'article</h2>
+            <p><em>Publié le 1 janvier 2024 par Auteur</em></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus suscipit, ex sit amet aliquet egestas, turpis orci varius libero, sit amet dapibus nisi ipsum a nunc.</p>
+            <p>Ut facilisis, libero sed imperdiet sodales, lacus eros tempus magna, vitae vestibulum nibh ipsum et nibh. Sed faucibus dictum nisl, vitae lacinia justo laoreet vitae.</p>
+            <p>Pour plus d'informations sur le film, consultez <a href="film.html">cette fiche</a>. Retrouvez également <a href="actor.html">l'acteur principal</a>.</p>
+        </article>
+    </main>
+    <footer>
+        <p>&copy; 2024 Codex. Tous droits réservés.</p>
+    </footer>
+</body>
+</html>

--- a/prototypes/styles.css
+++ b/prototypes/styles.css
@@ -1,0 +1,86 @@
+/* Shared styles for the Codex mockups */
+:root {
+    --primary-color: #d32f2f;
+    --secondary-color: #424242;
+    --light-bg: #f5f5f5;
+    --max-width: 1200px;
+    --font-stack: 'Helvetica Neue', Arial, sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: var(--font-stack);
+    background-color: var(--light-bg);
+    color: var(--secondary-color);
+}
+
+header {
+    background-color: #fff;
+    border-bottom: 2px solid var(--primary-color);
+    padding: 1rem 0;
+}
+
+header .container {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 1rem;
+}
+
+nav a {
+    margin: 0 0.5rem;
+    text-decoration: none;
+    color: var(--secondary-color);
+    font-weight: bold;
+}
+
+nav a:hover {
+    color: var(--primary-color);
+}
+
+main {
+    max-width: var(--max-width);
+    margin: 2rem auto;
+    padding: 0 1rem;
+}
+
+section {
+    margin-bottom: 2rem;
+}
+
+.cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 1rem;
+}
+
+.card {
+    background-color: #fff;
+    border-radius: 4px;
+    overflow: hidden;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    text-align: center;
+}
+
+.card img {
+    width: 100%;
+    height: 350px;
+    object-fit: cover;
+}
+
+.card h3 {
+    margin: 0.5rem 0;
+}
+
+footer {
+    background-color: #fff;
+    border-top: 1px solid #e0e0e0;
+    padding: 1rem 0;
+    text-align: center;
+}


### PR DESCRIPTION
## Summary
- add professional-quality HTML mockups for home, film, actor and news pages
- include shared stylesheet for consistent design
- document mockup directory in README

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be0242513883279c7ccade6ac83e58