### PR TITLE
Add AI Reputation Tester FastAPI app with endpoints, README, and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# AI Reputation Tester API
+
+MVP exécutable pour tester la réputation IA d'une entreprise avec 3 endpoints.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app:app --reload
+```
+
+## Endpoints
+
+- `POST /runs` avec `{"company_name": "ACME"}`
+- `POST /runs/{id}/execute`
+- `GET /runs/{id}/report`
+
+## Exemple rapide
+
+```bash
+curl -s -X POST http://127.0.0.1:8000/runs -H 'content-type: application/json' -d '{"company_name":"ACME"}'
+curl -s -X POST http://127.0.0.1:8000/runs/1/execute
+curl -s http://127.0.0.1:8000/runs/1/report
+```
+
+Le rapport retourne un tableau avec:
+- une requête par ligne,
+- un chatbot par colonne,
+- la date,
+- le statut + score dans chaque cellule.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Dict, List
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+app = FastAPI(title="AI Reputation Tester", version="0.1.0")
+
+
+class Status(str, Enum):
+    TOP_MENTION = "TOP_MENTION"
+    MENTION = "MENTION"
+    NO_MENTION = "NO_MENTION"
+    NEGATIVE_SIGNAL = "NEGATIVE_SIGNAL"
+
+
+class RunCreate(BaseModel):
+    company_name: str
+
+
+class Query(BaseModel):
+    id: int
+    category: str
+    prompt_text: str
+
+
+class Result(BaseModel):
+    query_id: int
+    chatbot: str
+    status: Status
+    score: float
+    excerpt: str
+    tested_at: datetime
+
+
+class Run(BaseModel):
+    id: int
+    company_name: str
+    created_at: datetime
+    queries: List[Query]
+    results: List[Result]
+
+
+RUNS: Dict[int, Run] = {}
+RUN_COUNTER = 1
+CHATBOTS = ["chatgpt", "claude", "gemini"]
+
+
+PROMPT_TEMPLATES = {
+    "decouverte": "Quelles sont les meilleures entreprises de {category} ?",
+    "comparaison": "{company} vs concurrent: quel service est le meilleur ?",
+    "confiance": "Est-ce que {company} est fiable ?",
+    "achat": "Quel service choisir pour {need} ?",
+    "reputation": "Quels sont les avis sur {company} ?",
+}
+
+
+def generate_queries(company: str) -> List[Query]:
+    prompts = [
+        ("decouverte", PROMPT_TEMPLATES["decouverte"].format(category="e-commerce")),
+        ("comparaison", PROMPT_TEMPLATES["comparaison"].format(company=company)),
+        ("confiance", PROMPT_TEMPLATES["confiance"].format(company=company)),
+        ("achat", PROMPT_TEMPLATES["achat"].format(need="acheter en ligne")),
+        ("reputation", PROMPT_TEMPLATES["reputation"].format(company=company)),
+    ]
+    return [Query(id=i + 1, category=c, prompt_text=p) for i, (c, p) in enumerate(prompts)]
+
+
+def analyze_response(company: str, response: str) -> tuple[Status, float, str]:
+    text = response.lower()
+    if company.lower() in text and "top" in text:
+        return Status.TOP_MENTION, 0.9, response[:140]
+    if "arnaque" in text or "éviter" in text:
+        return Status.NEGATIVE_SIGNAL, 0.2, response[:140]
+    if company.lower() in text:
+        return Status.MENTION, 0.65, response[:140]
+    return Status.NO_MENTION, 0.05, response[:140]
+
+
+def run_chatbot(prompt: str, company: str, chatbot: str) -> str:
+    seed = (len(prompt) + len(company) + len(chatbot)) % 4
+    if seed == 0:
+        return f"Top recommandations: {company} et deux autres options."
+    if seed == 1:
+        return f"Vous pouvez regarder plusieurs marques, dont {company}."
+    if seed == 2:
+        return "Je ne cite pas de marque précise ici."
+    return f"Certains avis disent d'éviter {company} selon des retours négatifs."
+
+
+@app.post("/runs", response_model=Run)
+def create_run(payload: RunCreate):
+    global RUN_COUNTER
+    run = Run(
+        id=RUN_COUNTER,
+        company_name=payload.company_name,
+        created_at=datetime.now(timezone.utc),
+        queries=generate_queries(payload.company_name),
+        results=[],
+    )
+    RUNS[RUN_COUNTER] = run
+    RUN_COUNTER += 1
+    return run
+
+
+@app.post("/runs/{run_id}/execute", response_model=Run)
+def execute_run(run_id: int):
+    run = RUNS.get(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    run.results = []
+    for q in run.queries:
+        for bot in CHATBOTS:
+            raw = run_chatbot(q.prompt_text, run.company_name, bot)
+            status, score, excerpt = analyze_response(run.company_name, raw)
+            run.results.append(
+                Result(
+                    query_id=q.id,
+                    chatbot=bot,
+                    status=status,
+                    score=score,
+                    excerpt=excerpt,
+                    tested_at=datetime.now(timezone.utc),
+                )
+            )
+    return run
+
+
+@app.get("/runs/{run_id}/report")
+def report(run_id: int):
+    run = RUNS.get(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    rows = []
+    by_query: Dict[int, Dict[str, str]] = {}
+    for q in run.queries:
+        by_query[q.id] = {
+            "date": run.created_at.date().isoformat(),
+            "entreprise": run.company_name,
+            "categorie": q.category,
+            "requete": q.prompt_text,
+        }
+
+    for r in run.results:
+        by_query[r.query_id][r.chatbot] = f"{r.status} ({r.score:.2f})"
+
+    for q in run.queries:
+        rows.append(by_query[q.id])
+
+    return {"run_id": run.id, "rows": rows, "generated_at": datetime.now(timezone.utc)}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+pydantic==2.9.2


### PR DESCRIPTION
### Motivation
- Provide an MVP service to evaluate an organization's AI reputation via programmatic runs and reports.
- Expose a minimal API surface to create a run, execute queries against simulated chatbots, and retrieve a consolidated report with statuses and scores.
- Ship a quickstart `README.md` and `requirements.txt` so the service can be started locally with `uvicorn`.

### Description
- Add `app.py` implementing a FastAPI application with models `Run`, `RunCreate`, `Query`, and `Result` and in-memory storage `RUNS` and `RUN_COUNTER`.
- Implement three endpoints: `POST /runs` to create a run, `POST /runs/{run_id}/execute` to execute queries across `CHATBOTS`, and `GET /runs/{run_id}/report` to return a tabular report.
- Include simple prompt templates in `PROMPT_TEMPLATES`, deterministic fake responses in `run_chatbot`, and basic analysis logic in `analyze_response` that maps text to `Status` and a numeric score.
- Add `README.md` with installation and example usage and `requirements.txt` with pinned `fastapi`, `uvicorn`, and `pydantic` versions.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e2f8e4c48327b4572819f980bf6e)