### PR TITLE
Add AI Reputation Tester FastAPI MVP with dashboard, static UI, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# AI Reputation Tester API
+
+API MVP exécutable pour tester la réputation IA d'une entreprise.
+
+## Priorité recommandée (très important)
+
+### 1) Commencer par le **dashboard**
+Oui, je te conseille de commencer par le dashboard.
+
+Pourquoi:
+- c'est la **valeur produit principale** (le rapport que l'utilisateur paie pour voir),
+- ça valide vite le cœur métier (requêtes, exécution, résultats, scoring),
+- ça permet d'itérer sur la data avant de polir l'acquisition marketing.
+
+La page de vente peut rester simple au début (headline + CTA) pendant que le dashboard devient solide.
+
+### 2) Copier les maquettes dans le projet ?
+Oui, bonne idée.
+
+Je recommande:
+- créer un dossier `design/` (ou `docs/design/`) avec:
+  - captures PNG/JPG,
+  - tokens de style (couleurs, typo, spacing),
+  - notes d'interaction (filtres, colonnes, tri, états vides/loading),
+- ne pas mélanger les assets design avec `static/` tant qu'ils ne sont pas intégrés dans l'UI finale.
+
+---
+
+## Fonctionnalités
+- Génération automatique de requêtes par intention.
+- Exécution multi-chatbots (configurable via `CHATBOTS`).
+- Analyse et classification (`TOP_MENTION`, `MENTION`, `NO_MENTION`, `NEGATIVE_SIGNAL`).
+- Rapport tabulaire par requête avec une colonne par chatbot.
+
+## Installation
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app:app --reload
+```
+
+## Configuration
+```bash
+export CHATBOTS="chatgpt,claude,gemini"
+```
+
+## Endpoints
+- `GET /health`
+- `POST /runs` body: `{"company_name":"ACME"}`
+- `POST /runs/{id}/execute`
+- `GET /runs/{id}/report`
+
+## Tests
+```bash
+pytest -q
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from fastapi import Request
+from pydantic import BaseModel, Field
+
+app = FastAPI(title="AI Reputation Tester", version="0.3.0")
+app.mount("/static", StaticFiles(directory="static"), name="static")
+templates = Jinja2Templates(directory="templates")
+
+
+class Status(str, Enum):
+    TOP_MENTION = "TOP_MENTION"
+    MENTION = "MENTION"
+    NO_MENTION = "NO_MENTION"
+    NEGATIVE_SIGNAL = "NEGATIVE_SIGNAL"
+
+
+class RunCreate(BaseModel):
+    company_name: str = Field(min_length=2, max_length=120)
+
+
+class Query(BaseModel):
+    id: int
+    category: str
+    prompt_text: str
+
+
+class Result(BaseModel):
+    query_id: int
+    chatbot: str
+    status: Status
+    score: float
+    excerpt: str
+    tested_at: datetime
+
+
+class Run(BaseModel):
+    id: int
+    company_name: str
+    created_at: datetime
+    queries: list[Query]
+    results: list[Result]
+
+
+RUNS: dict[int, Run] = {}
+RUN_COUNTER = 1
+CHATBOTS = [b.strip() for b in os.getenv("CHATBOTS", "chatgpt,claude,gemini").split(",") if b.strip()]
+
+PROMPT_CATEGORIES: dict[str, list[str]] = {
+    "decouverte": [
+        "Quelles sont les meilleures entreprises de {industry} ?",
+        "Cite 5 services connus en {industry}.",
+    ],
+    "comparaison": [
+        "{company} vs concurrent principal: avantages/inconvénients ?",
+        "Pour un client SMB, {company} ou alternative ?",
+    ],
+    "confiance": [
+        "Est-ce que {company} est fiable ?",
+        "Y a-t-il des signaux de risque pour {company} ?",
+    ],
+    "reputation": [
+        "Quels sont les avis sur {company} ?",
+        "La réputation de {company} est-elle positive ?",
+    ],
+}
+
+
+def generate_queries(company: str, industry: str = "e-commerce") -> list[Query]:
+    prompts: list[tuple[str, str]] = []
+    for category, templates in PROMPT_CATEGORIES.items():
+        for template in templates:
+            prompts.append((category, template.format(company=company, industry=industry)))
+    return [Query(id=i + 1, category=category, prompt_text=text) for i, (category, text) in enumerate(prompts)]
+
+
+def run_chatbot(prompt: str, company: str, chatbot: str) -> str:
+    # Stub déterministe (en prod: appel API fournisseur)
+    seed = (hash(prompt + company + chatbot) % 100) / 100
+    if seed < 0.25:
+        return f"Top recommandations: {company} est souvent cité en premier."
+    if seed < 0.55:
+        return f"Options possibles: {company} + autres alternatives du marché."
+    if seed < 0.80:
+        return "Réponse générale sans citer de marque spécifique."
+    return f"Certaines sources évoquent des points négatifs autour de {company}."
+
+
+def analyze_response(company: str, response: str) -> tuple[Status, float, str]:
+    text = response.lower()
+    brand = company.lower()
+    if brand in text and ("top" in text or "premier" in text):
+        return Status.TOP_MENTION, 0.9, response[:220]
+    if "négatif" in text or "risque" in text:
+        return Status.NEGATIVE_SIGNAL, 0.2, response[:220]
+    if brand in text:
+        return Status.MENTION, 0.65, response[:220]
+    return Status.NO_MENTION, 0.05, response[:220]
+
+
+def get_run_or_404(run_id: int) -> Run:
+    run = RUNS.get(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return run
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/runs", response_model=Run)
+def create_run(payload: RunCreate) -> Run:
+    global RUN_COUNTER
+    run = Run(
+        id=RUN_COUNTER,
+        company_name=payload.company_name.strip(),
+        created_at=datetime.now(timezone.utc),
+        queries=generate_queries(payload.company_name.strip()),
+        results=[],
+    )
+    RUNS[RUN_COUNTER] = run
+    RUN_COUNTER += 1
+    return run
+
+
+@app.post("/runs/{run_id}/execute", response_model=Run)
+def execute_run(run_id: int) -> Run:
+    run = get_run_or_404(run_id)
+    run.results = []
+    now = datetime.now(timezone.utc)
+    for q in run.queries:
+        for bot in CHATBOTS:
+            raw = run_chatbot(q.prompt_text, run.company_name, bot)
+            status, score, excerpt = analyze_response(run.company_name, raw)
+            run.results.append(
+                Result(
+                    query_id=q.id,
+                    chatbot=bot,
+                    status=status,
+                    score=score,
+                    excerpt=excerpt,
+                    tested_at=now,
+                )
+            )
+    return run
+
+
+@app.get("/runs/{run_id}/report")
+def report(run_id: int) -> dict[str, Any]:
+    run = get_run_or_404(run_id)
+
+    table_by_query: dict[int, dict[str, str]] = {
+        q.id: {
+            "date": run.created_at.date().isoformat(),
+            "entreprise": run.company_name,
+            "categorie": q.category,
+            "requete": q.prompt_text,
+        }
+        for q in run.queries
+    }
+
+    for item in run.results:
+        table_by_query[item.query_id][item.chatbot] = f"{item.status.value} ({item.score:.2f})"
+
+    rows = [table_by_query[q.id] for q in run.queries]
+    return {
+        "run_id": run.id,
+        "generated_at": datetime.now(timezone.utc),
+        "row_count": len(rows),
+        "rows": rows,
+    }
+
+
+@app.get("/", response_class=HTMLResponse)
+def home(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+pydantic==2.9.2
+pytest==8.3.3
+httpx==0.27.2
+jinja2==3.1.4

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,24 @@
+async function runTest(){
+  const company = document.getElementById('company').value.trim();
+  if(!company) return;
+  const created = await fetch('/runs',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({company_name:company})}).then(r=>r.json());
+  await fetch(`/runs/${created.id}/execute`,{method:'POST'});
+  const report = await fetch(`/runs/${created.id}/report`).then(r=>r.json());
+
+  const rows = report.rows;
+  const tb = document.querySelector('#reportTable tbody');
+  tb.innerHTML='';
+  let positive=0,total=0;
+  rows.forEach(row=>{
+    const tr=document.createElement('tr');
+    const cg=row.chatgpt||''; const cl=row.claude||''; const ge=row.gemini||'';
+    [row.requete,row.categorie,cg,cl,ge,row.date].forEach((val,idx)=>{const td=document.createElement('td');
+      if(idx>=2&&idx<=4){const status=(val.split(' ')[0]||'');td.innerHTML=`<span class="badge ${status}">${val}</span>`;if(status==='TOP_MENTION'||status==='MENTION')positive++;total++;}
+      else td.textContent=val;tr.appendChild(td);});
+    tb.appendChild(tr);
+  });
+  const score = total ? Math.round((positive/total)*100) : 0;
+  document.getElementById('score').textContent=`${score} /100`;
+  document.getElementById('summary').textContent=`${rows.length} requêtes analysées, ${total} cellules chatbot.`;
+}
+document.getElementById('runBtn').addEventListener('click',runTest);

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,13 @@
+body{font-family:Inter,Arial,sans-serif;margin:0;color:#171a2b;background:#f7f8ff}
+.topbar{display:flex;justify-content:space-between;align-items:center;padding:18px 32px;background:#fff;border-bottom:1px solid #e8eaf8}
+.logo{font-weight:800;font-size:30px}.topbar nav a{margin:0 10px;color:#545a75}
+.container{max-width:1150px;margin:30px auto;padding:0 16px}
+.hero{display:grid;grid-template-columns:1.2fr 1fr;gap:20px;align-items:start}
+h1{font-size:58px;line-height:1.05;margin:0 0 8px}h1 span{color:#5c5cff}
+.runbox{display:flex;gap:10px;margin-top:18px}input{flex:1;padding:14px;border:1px solid #d8dbef;border-radius:10px}
+.btn{padding:12px 16px;border-radius:10px;border:1px solid #d8dbef;background:#fff;font-weight:600}.primary{background:#5c5cff;color:#fff}
+.card{background:#fff;border:1px solid #e3e6f4;border-radius:16px;padding:20px}
+.score{font-size:42px;font-weight:800;color:#5c5cff;margin:8px 0}
+.report{margin-top:24px}table{width:100%;border-collapse:collapse}th,td{border-bottom:1px solid #eceffa;padding:10px;text-align:left;font-size:14px}th{color:#5f6683}
+.badge{padding:2px 8px;border-radius:8px;font-weight:700;font-size:12px;display:inline-block}
+.TOP_MENTION,.MENTION{background:#dcf6e8;color:#16834e}.NO_MENTION{background:#e9edf8;color:#5f6683}.NEGATIVE_SIGNAL{background:#fde2e2;color:#b43a3a}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AIRepute</title>
+  <link rel="stylesheet" href="/static/styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="logo">✦ AIRepute</div>
+    <nav>
+      <a>Product</a><a>Features</a><a>How it works</a><a>Pricing</a>
+    </nav>
+    <button class="btn primary">Start Free Trial</button>
+  </header>
+
+  <main class="container">
+    <section class="hero">
+      <div>
+        <h1>See how AI sees <span>your brand.</span></h1>
+        <p>Entrez votre entreprise, nous générons les prompts, lançons les tests et livrons un rapport clair.</p>
+        <div class="runbox">
+          <input id="company" placeholder="Nom de l'entreprise ou site" />
+          <button id="runBtn" class="btn primary">Run AI Reputation Test</button>
+        </div>
+      </div>
+      <div class="card">
+        <h3>AI Reputation Score</h3>
+        <div id="score" class="score">-- /100</div>
+        <p id="summary">Lancez un test pour voir le score.</p>
+      </div>
+    </section>
+
+    <section class="report card">
+      <h3>Report</h3>
+      <table id="reportTable">
+        <thead><tr><th>Query</th><th>Category</th><th>ChatGPT</th><th>Claude</th><th>Gemini</th><th>Date</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  </main>
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,37 @@
+from fastapi.testclient import TestClient
+
+from app import CHATBOTS, app
+
+
+client = TestClient(app)
+
+
+def test_health():
+    r = client.get('/health')
+    assert r.status_code == 200
+    assert r.json()['status'] == 'ok'
+
+
+def test_run_flow():
+    created = client.post('/runs', json={'company_name': 'ACME'})
+    assert created.status_code == 200
+    run = created.json()
+    assert run['company_name'] == 'ACME'
+    assert len(run['queries']) >= 4
+
+    executed = client.post(f"/runs/{run['id']}/execute")
+    assert executed.status_code == 200
+    data = executed.json()
+    assert len(data['results']) == len(data['queries']) * len(CHATBOTS)
+
+    report = client.get(f"/runs/{run['id']}/report")
+    assert report.status_code == 200
+    payload = report.json()
+    assert payload['row_count'] == len(data['queries'])
+    assert len(payload['rows']) == len(data['queries'])
+
+
+def test_home_page():
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "AIRepute" in r.text


### PR DESCRIPTION
### Motivation
- Provide a runnable MVP for evaluating how different chatbots mention a company and produce a per-query reputation report.
- Ship a simple dashboard so product value (reporting and scoring) can be validated quickly and iterated on.
- Offer a deterministic local stub for multi-chatbot execution to enable fast development without external API keys.

### Description
- Add a FastAPI application in `app.py` implementing endpoints `GET /health`, `POST /runs`, `POST /runs/{id}/execute`, `GET /runs/{id}/report`, and a root HTML dashboard at `/` using Jinja2 templates. 
- Implement query generation via `PROMPT_CATEGORIES`, a deterministic `run_chatbot` stub, and `analyze_response` to map responses to `Status` (`TOP_MENTION`, `MENTION`, `NO_MENTION`, `NEGATIVE_SIGNAL`).
- Include a simple frontend under `templates/` and `static/` (`index.html`, `app.js`, `styles.css`) that creates runs, triggers execution, and renders a tabular report and score.
- Add project metadata and dependencies in `requirements.txt`, a `README.md` describing usage and endpoints, and an automated test suite in `tests/test_app.py` that exercises the core API and home page.

### Testing
- Ran the FastAPI test client suite via `pytest -q` which executed `tests/test_app.py` covering `test_health`, `test_run_flow`, and `test_home_page` and all tests passed.
- Confirmed the `GET /health` endpoint returns `{"status":"ok"}` as expected.
- Verified that creating a run, executing it, and retrieving the report returns consistent `queries`, `results`, and `rows` counts as asserted by the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e2f8e4c48327b4572819f980bf6e)